### PR TITLE
feat: change deployment strategy to recreate

### DIFF
--- a/templates/apprise/deployment.yaml
+++ b/templates/apprise/deployment.yaml
@@ -10,7 +10,7 @@ spec:
   revisionHistoryLimit: 3
   replicas: {{ .Values.services.apprise.replicaCount }}
   strategy:
-    type: RollingUpdate
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: apprise

--- a/templates/autobrr/deployment.yaml
+++ b/templates/autobrr/deployment.yaml
@@ -11,7 +11,7 @@ spec:
   revisionHistoryLimit: 3
   replicas: {{ .Values.services.autobrr.replicaCount }}
   strategy:
-    type: RollingUpdate
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: autobrr

--- a/templates/changedetectionio/deployment.yaml
+++ b/templates/changedetectionio/deployment.yaml
@@ -10,7 +10,7 @@ spec:
   revisionHistoryLimit: 3
   replicas: {{ .Values.services.changedetectionio.replicaCount }}
   strategy:
-    type: RollingUpdate
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: changedetectionio

--- a/templates/cloudflared/deployment.yaml
+++ b/templates/cloudflared/deployment.yaml
@@ -3,15 +3,21 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cloudflared
+  namespace: default
+  labels:
+    app.kubernetes.io/name: cloudflared
 spec:
   selector:
     matchLabels:
-      app: cloudflared
-  replicas: {{ .Values.services.cloudflared.replicaCount }} # You could also consider elastic scaling for this deployment
+      app.kubernetes.io/name: cloudflared
+  revisionHistoryLimit: 3
+  replicas: {{ .Values.services.cloudflared.replicaCount }}
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
-        app: cloudflared
+        app.kubernetes.io/name: cloudflared
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/cloudflared/configmap.yaml") . | sha256sum}}
         checksum/file: {{ (.Files.Get "files/cloudflared.conf") | sha256sum }}

--- a/templates/gotify/deployment.yaml
+++ b/templates/gotify/deployment.yaml
@@ -10,7 +10,7 @@ spec:
   revisionHistoryLimit: 3
   replicas: {{ .Values.services.gotify.replicaCount }}
   strategy:
-    type: RollingUpdate
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: gotify

--- a/templates/homepage/deployment.yaml
+++ b/templates/homepage/deployment.yaml
@@ -10,7 +10,7 @@ spec:
   revisionHistoryLimit: 3
   replicas: {{ .Values.services.homepage.replicaCount }}
   strategy:
-    type: RollingUpdate
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: homepage

--- a/templates/huginn/deployment.yaml
+++ b/templates/huginn/deployment.yaml
@@ -10,7 +10,7 @@ spec:
   revisionHistoryLimit: 3
   replicas: {{ .Values.services.huginn.replicaCount }}
   strategy:
-    type: RollingUpdate
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: huginn

--- a/templates/kavita/deployment.yaml
+++ b/templates/kavita/deployment.yaml
@@ -10,7 +10,7 @@ spec:
   revisionHistoryLimit: 3
   replicas: {{ .Values.services.kavita.replicaCount }}
   strategy:
-    type: RollingUpdate
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: kavita

--- a/templates/nginx/deployment.yaml
+++ b/templates/nginx/deployment.yaml
@@ -11,7 +11,7 @@ spec:
     matchLabels:
       app: nginx
   strategy:
-    type: RollingUpdate
+    type: Recreate
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0

--- a/templates/overseerr/deployment.yaml
+++ b/templates/overseerr/deployment.yaml
@@ -10,7 +10,7 @@ spec:
   revisionHistoryLimit: 3
   replicas: {{ .Values.services.overseerr.replicaCount }}
   strategy:
-    type: RollingUpdate
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: overseerr

--- a/templates/playwright/deployment.yaml
+++ b/templates/playwright/deployment.yaml
@@ -10,7 +10,7 @@ spec:
   revisionHistoryLimit: 3
   replicas: {{ .Values.services.playwright.replicaCount }}
   strategy:
-    type: RollingUpdate
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: playwright

--- a/templates/plex/deployment.yaml
+++ b/templates/plex/deployment.yaml
@@ -10,7 +10,7 @@ spec:
   revisionHistoryLimit: 3
   replicas: {{ .Values.services.plex.replicaCount }}
   strategy:
-    type: RollingUpdate
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: plex

--- a/templates/prowlarr/deployment.yaml
+++ b/templates/prowlarr/deployment.yaml
@@ -10,7 +10,7 @@ spec:
   revisionHistoryLimit: 3
   replicas: {{ .Values.services.prowlarr.replicaCount }}
   strategy:
-    type: RollingUpdate
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: prowlarr

--- a/templates/qbittorrent/deployment.yaml
+++ b/templates/qbittorrent/deployment.yaml
@@ -10,7 +10,7 @@ spec:
   revisionHistoryLimit: 3
   replicas: {{ .Values.services.qbittorrent.replicaCount }}
   strategy:
-    type: RollingUpdate
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: qbittorrent

--- a/templates/radarr/deployment.yaml
+++ b/templates/radarr/deployment.yaml
@@ -10,7 +10,7 @@ spec:
   revisionHistoryLimit: 3
   replicas: {{ .Values.services.radarr.replicaCount }}
   strategy:
-    type: RollingUpdate
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: radarr

--- a/templates/sabnzbd/deployment.yaml
+++ b/templates/sabnzbd/deployment.yaml
@@ -10,7 +10,7 @@ spec:
   revisionHistoryLimit: 3
   replicas: {{ .Values.services.sabnzbd.replicaCount }}
   strategy:
-    type: RollingUpdate
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: sabnzbd

--- a/templates/sonarr/deployment.yaml
+++ b/templates/sonarr/deployment.yaml
@@ -10,7 +10,7 @@ spec:
   revisionHistoryLimit: 3
   replicas: {{ .Values.services.sonarr.replicaCount }}
   strategy:
-    type: RollingUpdate
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: sonarr

--- a/templates/tautulli/deployment.yaml
+++ b/templates/tautulli/deployment.yaml
@@ -10,7 +10,7 @@ spec:
   revisionHistoryLimit: 3
   replicas: {{ .Values.services.tautulli.replicaCount }}
   strategy:
-    type: RollingUpdate
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: tautulli

--- a/templates/thelounge/deployment.yaml
+++ b/templates/thelounge/deployment.yaml
@@ -10,7 +10,7 @@ spec:
   revisionHistoryLimit: 3
   replicas: {{ .Values.services.thelounge.replicaCount }}
   strategy:
-    type: RollingUpdate
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: thelounge


### PR DESCRIPTION
Change the default deployment strategy to `Recreate` in order to avoid potential data corruption when dealing with stateful applications. This will result in a small amount of downtime when updating services. We will revisit zero downtime updates soon.

resolves #24 